### PR TITLE
The link to httriri wasn't mentioned in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![screenshot of HTTRiRi website](public/homepage-screenshot.png)
 
-Explore HTTP status codes with this collection of Rihanna GIFs. Each GIF links to the relevant https://httpstatuses.com/ page.
+Explore HTTP status codes with this collection of Rihanna GIFs at https://www.httriri.com/. Each GIF links to the relevant https://httpstatuses.com/ page.
 
 This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
 


### PR DESCRIPTION
The httriri link was only situated in About section of the repository, which can sometimes go unnoticed.
In this PR I added it in the Readme section! :)